### PR TITLE
Avoid brace expansion to fix build under dash

### DIFF
--- a/conf/machine/solidrun-imx6.conf
+++ b/conf/machine/solidrun-imx6.conf
@@ -29,7 +29,20 @@ BOOT_SCRIPTS = "${UENV_FILENAME}:uEnv.txt"
 
 KERNEL_IMAGETYPE = "zImage"
 # KERNEL_DEVICETREE = "imx6dl-cubox-i.dtb imx6q-cubox-i.dtb imx6dl-hummingboard.dtb imx6q-hummingboard.dtb imx6dl-hummingboard2.dtb imx6q-hummingboard2.dtb"
-KERNEL_DEVICETREE = "imx6{q,dl}-{cubox-i,hummingboard,hummingboard2}.dtb imx6{q,dl}-{cubox-i,hummingboard,hummingboard2}-som-v15.dtb"
+KERNEL_DEVICETREE = " \
+  imx6dl-cubox-i.dtb \
+  imx6q-cubox-i.dtb \
+  imx6dl-hummingboard.dtb \
+  imx6q-hummingboard.dtb \
+  imx6dl-hummingboard2.dtb \
+  imx6q-hummingboard2.dtb \
+  imx6dl-cubox-i-som-v15.dtb \
+  imx6q-cubox-i-som-v15.dtb \
+  imx6dl-hummingboard-som-v15.dtb \
+  imx6q-hummingboard-som-v15.dtb \
+  imx6dl-hummingboard2-som-v15.dtb \
+  imx6q-hummingboard2-som-v15.dtb \
+"
 
 MACHINE_FEATURES += "pci wifi bluetooth alsa irda serial usbhost"
 MACHINE_EXTRA_RRECOMMENDS += "bcm4330-nvram-config bcm4329-nvram-config"


### PR DESCRIPTION
Brace expansion is a Bash feature that is not universally supported. Avoid
this feature to fix the following build failure:

make[3]: *** No rule to make target `arch/arm/boot/dts/imx6{q,dl}-{cubox-i,hummingboard,hummingboard2}.dtb'.  Stop