### PR TITLE
Fix branch names and freescale repo

### DIFF
--- a/README
+++ b/README
@@ -7,11 +7,11 @@ use with OpenEmbedded and/or Yocto Freescale's BSP layer.
 This layer depends on:
 
 URI: git://git.openembedded.org/openembedded-core
-branch: fido
+branch: rocko
 revision: HEAD
 
-URI: git://git.yoctoproject.org/meta-fsl-arm
-branch: fido
+URI: git://git.yoctoproject.org/meta-freescale
+branch: rocko
 revision: HEAD
 
 Contributing


### PR DESCRIPTION
Exchange fido for rocko, meta-freescale is the new meta-fsl-arm.
We are now on rockmeta-fsl-arm doesn't exist anymore for rocko branch.